### PR TITLE
refine xeon ci and move xeon ci to gnr

### DIFF
--- a/.github/workflows/pr-test-xeon.yml
+++ b/.github/workflows/pr-test-xeon.yml
@@ -12,7 +12,7 @@ concurrency:
 jobs:
   build-test:
     if: github.event_name == 'pull_request'
-    runs-on: sglang-pvc
+    runs-on: sglang-gnr
     strategy:
       matrix:
         build_type: ['all']
@@ -58,6 +58,11 @@ jobs:
           docker exec -w /sglang-checkout/ ci_sglang_xeon \
             bash -c "cd ./test/srt && python3 run_suite.py --suite per-commit-cpu"
 
+      - name: Change permissions
+        if: ${{ always() }}
+        run: |
+          docker exec -t ci_sglang_xeon bash -c "sudo chown -R 1001:1001 test"
+          
       - name: Cleanup container
         if: always()
         run: |
@@ -66,7 +71,7 @@ jobs:
   finish:
     if: always()
     needs: [build-test]
-    runs-on: ubuntu-24.04
+    runs-on: sglang-gnr
     steps:
       - name: Check all dependent job statuses
         run: |

--- a/.github/workflows/pr-test-xeon.yml
+++ b/.github/workflows/pr-test-xeon.yml
@@ -40,7 +40,7 @@ jobs:
         timeout-minutes: 20
         run: |
           docker exec -u root ci_sglang_xeon bash -c "
-            rm -rf /tmp/ci-home && mkdir -p /tmp/ci-home &&
+            rm -rf /tmp/ci-home  &&
             chmod -R w /sgl-workspace/miniforge3/lib/python3.12/site-packages 2>/dev/null || true
           "
       - name: Install Dependency

--- a/.github/workflows/pr-test-xeon.yml
+++ b/.github/workflows/pr-test-xeon.yml
@@ -40,7 +40,7 @@ jobs:
         timeout-minutes: 20
         run: |
           docker exec -u root ci_sglang_xeon bash -c "
-            mkdir -p /tmp/ci-home &&
+            rm -rf /tmp/ci-home && mkdir -p /tmp/ci-home &&
             chmod -R w /sgl-workspace/miniforge3/lib/python3.12/site-packages 2>/dev/null || true
           "
       - name: Install Dependency

--- a/.github/workflows/pr-test-xeon.yml
+++ b/.github/workflows/pr-test-xeon.yml
@@ -38,11 +38,11 @@ jobs:
       - name: Install Dependency
         timeout-minutes: 20
         run: |
-          docker exec ci_sglang_xeon bash -c "python3 -m pip install --upgrade pip"
+          docker exec ci_sglang_xeon bash -c "python3 -m pip install --user --upgrade pip"
           docker exec ci_sglang_xeon pip uninstall sgl-kernel -y || true
           docker exec -w /sglang-checkout/sgl-kernel ci_sglang_xeon bash -c "cp pyproject_cpu.toml pyproject.toml && pip install -v ."
           docker exec -w /sglang-checkout/ ci_sglang_xeon bash -c "pip install -e "python[all_cpu]""
-          docker exec ci_sglang_xeon bash -c "python3 -m pip install pytest expecttest"
+          docker exec ci_sglang_xeon bash -c "python3 -m pip install --user pytest expecttest"
 
       - name: Check AMX Support
         id: check_amx

--- a/.github/workflows/pr-test-xeon.yml
+++ b/.github/workflows/pr-test-xeon.yml
@@ -41,7 +41,7 @@ jobs:
         run: |
           docker exec -u root ci_sglang_xeon bash -c "
             rm -rf /tmp/ci-home  &&
-            chmod -R w /sgl-workspace/miniforge3/lib/python3.12/site-packages 2>/dev/null || true
+            chown -R  $(id -u):$(id -g) /sgl-workspace/miniforge3/lib/python3.12/site-packages 2>/dev/null || true
           "
       - name: Install Dependency
         timeout-minutes: 20

--- a/.github/workflows/pr-test-xeon.yml
+++ b/.github/workflows/pr-test-xeon.yml
@@ -36,6 +36,13 @@ jobs:
             --name ci_sglang_xeon \
             sglang_xeon
 
+      - name: Change permission
+        timeout-minutes: 20
+        run: |
+          docker exec ci_sglang_xeon bash -c "
+            mkdir -p /tmp/ci-home &&
+            chmod -R a+w /sgl-workspace/miniforge3/lib/python3.12/site-packages 2>/dev/null || true
+          "
       - name: Install Dependency
         timeout-minutes: 20
         run: |

--- a/.github/workflows/pr-test-xeon.yml
+++ b/.github/workflows/pr-test-xeon.yml
@@ -30,6 +30,7 @@ jobs:
       - name: Run container
         run: |
           docker run -dt \
+            --user $(id -u):$(id -g) \
             -v ${{ github.workspace }}:/sglang-checkout/ --ipc=host \
             --name ci_sglang_xeon \
             sglang_xeon
@@ -57,11 +58,6 @@ jobs:
         run: |
           docker exec -w /sglang-checkout/ ci_sglang_xeon \
             bash -c "cd ./test/srt && python3 run_suite.py --suite per-commit-cpu"
-
-      - name: Change permissions
-        if: ${{ always() }}
-        run: |
-          docker exec -t ci_sglang_xeon bash -c "chown -R 1001:1001 /sglang-checkout/"
 
       - name: Cleanup container
         if: always()

--- a/.github/workflows/pr-test-xeon.yml
+++ b/.github/workflows/pr-test-xeon.yml
@@ -39,9 +39,9 @@ jobs:
       - name: Change permission
         timeout-minutes: 20
         run: |
-          docker exec ci_sglang_xeon bash -c "
+          docker exec -u root ci_sglang_xeon bash -c "
             mkdir -p /tmp/ci-home &&
-            chmod -R a+w /sgl-workspace/miniforge3/lib/python3.12/site-packages 2>/dev/null || true
+            chmod -R w /sgl-workspace/miniforge3/lib/python3.12/site-packages 2>/dev/null || true
           "
       - name: Install Dependency
         timeout-minutes: 20

--- a/.github/workflows/pr-test-xeon.yml
+++ b/.github/workflows/pr-test-xeon.yml
@@ -31,7 +31,7 @@ jobs:
         run: |
           docker run -dt \
             --user $(id -u):$(id -g) \
-            -e HOME=/home \
+            -e HOME=/tmp/ci-home \
             -v ${{ github.workspace }}:/sglang-checkout/ --ipc=host \
             --name ci_sglang_xeon \
             sglang_xeon

--- a/.github/workflows/pr-test-xeon.yml
+++ b/.github/workflows/pr-test-xeon.yml
@@ -61,8 +61,8 @@ jobs:
       - name: Change permissions
         if: ${{ always() }}
         run: |
-          docker exec -t ci_sglang_xeon bash -c "sudo chown -R 1001:1001 test"
-          
+          docker exec -t ci_sglang_xeon bash -c "chown -R 1001:1001 /sglang-checkout/"
+
       - name: Cleanup container
         if: always()
         run: |

--- a/.github/workflows/pr-test-xeon.yml
+++ b/.github/workflows/pr-test-xeon.yml
@@ -31,6 +31,7 @@ jobs:
         run: |
           docker run -dt \
             --user $(id -u):$(id -g) \
+            -e HOME=/home \
             -v ${{ github.workspace }}:/sglang-checkout/ --ipc=host \
             --name ci_sglang_xeon \
             sglang_xeon
@@ -38,11 +39,11 @@ jobs:
       - name: Install Dependency
         timeout-minutes: 20
         run: |
-          docker exec ci_sglang_xeon bash -c "python3 -m pip install --user --upgrade pip"
+          docker exec ci_sglang_xeon bash -c "python3 -m pip install --upgrade pip"
           docker exec ci_sglang_xeon pip uninstall sgl-kernel -y || true
           docker exec -w /sglang-checkout/sgl-kernel ci_sglang_xeon bash -c "cp pyproject_cpu.toml pyproject.toml && pip install -v ."
           docker exec -w /sglang-checkout/ ci_sglang_xeon bash -c "pip install -e "python[all_cpu]""
-          docker exec ci_sglang_xeon bash -c "python3 -m pip install --user pytest expecttest"
+          docker exec ci_sglang_xeon bash -c "python3 -m pip install pytest expecttest"
 
       - name: Check AMX Support
         id: check_amx


### PR DESCRIPTION
This PR enhances the SGLang CI pipeline on the Xeon platform with two key improvements:

Platform Migration: Migrates the CI tests from the current platform to the newer GNR (Granite Rapids) platform.

Permission Hardening: Optimizes the Docker container's permission settings to resolve potential permission-related issues in the CI workflow.

Testing and Validation
All changes have been tested locally, and a successful CI run on the new GNR platform is expected upon merging this PR.